### PR TITLE
NullPointerException, 역직렬화 수정

### DIFF
--- a/src/main/java/persistence/dto/DTO.java
+++ b/src/main/java/persistence/dto/DTO.java
@@ -11,6 +11,7 @@ import persistence.enums.RegistStatus;
 import sharing.Serializable;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 
@@ -37,15 +38,35 @@ public abstract class DTO implements Serializable {
                     arr = Serializer.longToByteArray((long)memberVal);
                 }
                 else if (type.contains("String")) {
-                    arr = ((String)memberVal).getBytes();
+                    if((String)memberVal != null) {
+                        arr = ((String) memberVal).getBytes();
+                    }
+
+                    else {
+                        arr = new byte[0];
+                    }
+
                     isDynamic = true;
                 }
                 else if (type.contains("LocalDateTime")) {
-                    arr = Serializer.dateToByteArray((LocalDateTime)memberVal);
+                    if((LocalDateTime)memberVal != null) {
+                        arr = Serializer.dateToByteArray((LocalDateTime) memberVal);
+                    }
+
+                    else {
+                        arr = new byte[0];
+                    }
+
                     isDynamic = true;
                 }
                 else if (type.contains("enums")) {
-                    arr = Serializer.enumToByteArray((Enum)memberVal);
+                    if((Enum)memberVal != null) {
+                        arr = Serializer.enumToByteArray((Enum) memberVal);
+                    }
+
+                    else {
+                        arr = new byte[0];
+                    }
                 }
             } catch (IllegalAccessException e) {
                 e.printStackTrace();
@@ -141,6 +162,8 @@ public abstract class DTO implements Serializable {
                     System.arraycopy(codeByteArray, 0, arr, idx, INT_LENGTH); idx += INT_LENGTH;
                     memberVal = RegistStatus.of(Deserializer.byteArrayToInt(codeByteArray));
                 }
+
+                classMembers[i].set(this, memberVal);
             } catch (IllegalAccessException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
[로그]
1. NullPointerException 오류 수정
2. 역직렬화 시 멤버 변수의 값이 변경되도록 함.

1 - DTO의 멤버로 객체가 있을 경우 기본 생성자를 통해 DTO를 인스턴스화 할 때 해당 멤버는 Null이 되는데 객체가 Null임에도 직렬화하려고 하였기 때문에 발생했던 오류였음. 본래 시리얼라이저에서 null인 경우를 체크하는게 맞을거 같으나, String의 경우 자체적으로 구현되어 있어 로직 수정이 불가능했기 때문에 코드의 일관성을 살리기 위하여 DTO에서 Null을 체크하도록 변경

2 - 역직렬화 시 리플렉션으로 멤버를 받아와서 초기화까지 했지만 해당 멤버 변수의 값을 변경하는 코드가 빠져있었음. 해당 사항 수정함. private 멤버를 받아서 직접적으로 값을 수정하는거라서 찝찝하긴 하지만 다른 방법이 있는지 모르겠음.